### PR TITLE
table wrap bug fix

### DIFF
--- a/src/report/ReportRecordProcessing.tsx
+++ b/src/report/ReportRecordProcessing.tsx
@@ -269,16 +269,17 @@ function RenderArray(value, transposedTable = false) {
     mapped = value.map((v, i) => {
       return RenderSubValue(v) + (i < value.length - 1 ? ', ' : '');
     });
-  }
-  // Render Node and Relationship objects, which will look like a Path
-  mapped = value.map((v, i) => {
-    return (
-      <span key={String(`k${i}`) + v}>
-        {RenderSubValue(v)}
-        {i < value.length - 1 && !valueIsNode(v) && !valueIsRelationship(v) ? <span>, </span> : <></>}
-      </span>
-    );
-  });
+  } else {
+    // Render Node and Relationship objects, which will look like a Path
+    mapped = value.map((v, i) => {
+      return (
+        <span key={String(`k${i}`) + v}>
+          {RenderSubValue(v)}
+          {i < value.length - 1 && !valueIsNode(v) && !valueIsRelationship(v) ? <span>, </span> : <></>}
+        </span>
+      );
+    });
+  };
   return mapped;
 }
 


### PR DESCRIPTION
Fixes issue with table chart no wrapping arrays correctly:

BEFORE:
<img width="1308" alt="Screenshot 2024-08-07 at 15 51 24" src="https://github.com/user-attachments/assets/b606bd93-2475-47eb-a69b-f16def917945">

AFTER:
<img width="1308" alt="Screenshot 2024-08-07 at 15 52 45" src="https://github.com/user-attachments/assets/5637bf03-2352-4117-9797-781c69816df7">

